### PR TITLE
python pip no longer able to update packages installed by regular package manager.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxserver/baseimage
 MAINTAINER sparklyballs <sparklyballs@linuxserver.io>
-ENV BASE_APTLIST="build-essential libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python-lxml python-pip unrar unzip wget"
+ENV BASE_APTLIST="libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python-lxml python-pip unrar unzip wget"
 
 #ENV PYTHONIOENCODING="UTF-8" 
 ADD 21_pip_update.sh /etc/my_init.d/21_pip_update.sh
@@ -11,10 +11,16 @@ RUN add-apt-repository ppa:fkrull/deadsnakes-python2.7 && \
 apt-get update -q && \
 apt-get install $BASE_APTLIST -qy && \
 
+# upgrade python-requests package
+curl -o /tmp/requests.tar.gz  -L https://github.com/kennethreitz/requests/tarball/master && \
+mkdir -p /tmp/request_source && \
+tar xvf /tmp/requests.tar.gz -C /tmp/request_source --strip-components=1 && \
+cd /tmp/request_source && \
+python setup.py install && \
 
 #install pip packages
 pip install pip-review && \
-pip install -U pip request pyopenssl ndg-httpsclient virtualenv && \
+pip install -U pip pyopenssl ndg-httpsclient virtualenv && \
 
 # cleanup 
 apt-get clean -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxserver/baseimage
 MAINTAINER sparklyballs <sparklyballs@linuxserver.io>
-ENV BASE_APTLIST="libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python2.7-dev python-lxml python-pip unrar unzip wget"
+ENV BASE_APTLIST="build-essential libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python-lxml python-pip unrar unzip wget"
 
 #ENV PYTHONIOENCODING="UTF-8" 
 ADD 21_pip_update.sh /etc/my_init.d/21_pip_update.sh
@@ -14,7 +14,7 @@ apt-get install $BASE_APTLIST -qy && \
 
 #install pip packages
 pip install pip-review && \
-pip install -U pip pyopenssl ndg-httpsclient virtualenv && \
+pip install -U pip request pyopenssl ndg-httpsclient virtualenv && \
 
 # cleanup 
 apt-get clean -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,14 @@ tar xvf /tmp/requests.tar.gz -C /tmp/request_source --strip-components=1 && \
 cd /tmp/request_source && \
 python setup.py install && \
 
+# upgrade urllib3 package
+curl -o /tmp/urllib3.tar.gz -L https://pypi.python.org/packages/source/u/urllib3/urllib3-1.14.tar.gz && \
+mkdir -p /tmp/urllib3_source && \
+tar xvf /tmp/urllib3.tar.gz -C /tmp/urllib3_source --strip-components=1 && \
+cd /tmp/urllib3_source && \
+make && \
+make install && \
+
 #install pip packages
 pip install pip-review && \
 pip install -U pip pyopenssl ndg-httpsclient virtualenv && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ cd /tmp/request_source && \
 python setup.py install && \
 
 # upgrade urllib3 package
-curl -o /tmp/urllib3.tar.gz -L https://pypi.python.org/packages/source/u/urllib3/urllib3-1.14.tar.gz && \
+curl -o /tmp/urllib3.tar.gz -L https://github.com/shazow/urllib3/tarball/master  && \
 mkdir -p /tmp/urllib3_source && \
 tar xvf /tmp/urllib3.tar.gz -C /tmp/urllib3_source --strip-components=1 && \
 cd /tmp/urllib3_source && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,7 @@ curl -o /tmp/urllib3.tar.gz -L https://pypi.python.org/packages/source/u/urllib3
 mkdir -p /tmp/urllib3_source && \
 tar xvf /tmp/urllib3.tar.gz -C /tmp/urllib3_source --strip-components=1 && \
 cd /tmp/urllib3_source && \
-make && \
-make install && \
+python setup.py install && \
 
 #install pip packages
 pip install pip-review && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM linuxserver/baseimage
 MAINTAINER sparklyballs <sparklyballs@linuxserver.io>
-ENV BASE_APTLIST="libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python-lxml python-pip unrar unzip wget"
+ENV BASE_APTLIST="libxslt1-dev git-core libffi-dev libffi6 libpython-dev libssl-dev python2.7 python-cherrypy python-lxml python-pip python2.7-dev unrar unzip wget"
 
 #ENV PYTHONIOENCODING="UTF-8" 
 ADD 21_pip_update.sh /etc/my_init.d/21_pip_update.sh


### PR DESCRIPTION
The two main packages that stop our usenet and torrent based apps interacting with some providers are requests and urllib3.

the packages that are in the repos for ubuntu 14.04 are out of date, they come along as part of the python-pip package itself.

so resorting to pulling them from git source and installing via python setup.py.
