### PR TITLE
Delete 21_pip_update.sh

### DIFF
--- a/21_pip_update.sh
+++ b/21_pip_update.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# opt out for autoupdate
-[ "$ADVANCED_DISABLEUPDATES" ] && exit 0
-
-pip-review --local --auto


### PR DESCRIPTION
there is something wrong with pip servers.

on my personal unraid every single python based container is failing 

and i've seen a few mentions of CP in particular already with this.
